### PR TITLE
Fixed bug with output manifests not being truncated

### DIFF
--- a/src/SFPackager/Services/Manifest/ManifestLoader.cs
+++ b/src/SFPackager/Services/Manifest/ManifestLoader.cs
@@ -27,7 +27,7 @@ namespace SFPackager.Services.Manifest
 
         public void Save(T manifest, string manifestPath)
         {
-            using (var writer = new FileStream(manifestPath, FileMode.OpenOrCreate, FileAccess.Write))
+            using (var writer = new FileStream(manifestPath, FileMode.Truncate, FileAccess.Write))
             {
                 _serializer.Serialize(writer, manifest);
             }

--- a/src/SFPackager/Services/ServiceHashCalculator.cs
+++ b/src/SFPackager/Services/ServiceHashCalculator.cs
@@ -145,7 +145,7 @@ namespace SFPackager.Services
 
             var serviceNames = project.Services.Select(x => x.Key).ToList();
 
-            var appManifest = _appManifestLoader.Load("");
+            var appManifest = _appManifestLoader.Load(project.ApplicationManifestFileFullPath);
             _manifestHandler.CleanAppManifest(appManifest);
             _handleEndpointCert.SetEndpointCerts(_packageConfig, appManifest, project.ApplicationTypeName);
             _handleEnciphermentCert.SetEnciphermentCerts(_packageConfig, appManifest, project.ApplicationTypeName);

--- a/test/SFPackager.Tests/DescribeManifest/DescribeCertificateAppender.cs
+++ b/test/SFPackager.Tests/DescribeManifest/DescribeCertificateAppender.cs
@@ -12,7 +12,7 @@ namespace SFPackager.Tests.DescribeManifest
     public class DescribeCertificateAppender
     {
         [Fact]
-        public void ItHandlesASingleCertOnASignleEndpoint()
+        public void ItHandlesASingleCertOnASingleEndpoint()
         {
             // g
             var packageConfig = new PackageConfig
@@ -59,6 +59,151 @@ namespace SFPackager.Tests.DescribeManifest
 
             var endpointCertificate = appManifest.Certificates.EndpointCertificates.First();
 
+            endpointCertificate.Name.Should().Be("Certificate0");
+            endpointCertificate.X509FindValue.Should().Be("MyCert");
+        }
+
+        [Fact]
+        public void ItHandlesTwoCertsSpreadOnTwoEndpoints()
+        {
+            // g
+            var packageConfig = new PackageConfig
+            {
+                Https = new List<HttpsConfig>
+                {
+                    new HttpsConfig
+                    {
+                        ApplicationTypeName = "MyApp",
+                        CertThumbprint = "MyCert",
+                        ServiceManifestName = "MyService",
+                        EndpointName = "MyEndpoint"
+                    },
+                    new HttpsConfig
+                    {
+                        ApplicationTypeName = "MyApp",
+                        CertThumbprint = "MyOtherCert",
+                        ServiceManifestName = "MyOtherService",
+                        EndpointName = "MyOtherEndpoint"
+                    }
+                }
+            };
+
+            var appManifest = new ApplicationManifest
+            {
+                ServiceManifestImports = new List<ServiceManifestImport>
+                {
+                    new ServiceManifestImport
+                    {
+                        ServiceManifestRef = new ServiceManifestRef
+                        {
+                            ServiceManifestName = "MyService"
+                        }
+                    },
+                    new ServiceManifestImport
+                    {
+                        ServiceManifestRef = new ServiceManifestRef
+                        {
+                            ServiceManifestName = "MyOtherService"
+                        }
+                    }
+                }
+            };
+
+            var endpointHandler = new HandleEndpointCert();
+
+            // w
+            endpointHandler.SetEndpointCerts(packageConfig, appManifest, "MyApp");
+
+            // t
+            var endpointBindingPolicy = appManifest
+                .ServiceManifestImports.First()
+                .Policies
+                .EndpointBindingPolicy.First();
+
+            endpointBindingPolicy.EndpointRef.Should().Be("MyEndpoint");
+            endpointBindingPolicy.CertificateRef.Should().Be("Certificate0");
+
+            var endpointCertificate = appManifest.Certificates.EndpointCertificates.First();
+
+            endpointCertificate.Name.Should().Be("Certificate0");
+            endpointCertificate.X509FindValue.Should().Be("MyCert");
+
+            var otherEndpointBindingPolicy = appManifest
+                .ServiceManifestImports.Last()
+                .Policies
+                .EndpointBindingPolicy.First();
+
+            otherEndpointBindingPolicy.EndpointRef.Should().Be("MyOtherEndpoint");
+            otherEndpointBindingPolicy.CertificateRef.Should().Be("Certificate1");
+
+            var otherEndpointCertificate = appManifest.Certificates.EndpointCertificates.Last();
+
+            otherEndpointCertificate.Name.Should().Be("Certificate1");
+            otherEndpointCertificate.X509FindValue.Should().Be("MyOtherCert");
+        }
+
+        [Fact]
+        public void ItHandlesSingleCertOnTwoEndpoints()
+        {
+            // g
+            var packageConfig = new PackageConfig
+            {
+                Https = new List<HttpsConfig>
+                {
+                    new HttpsConfig
+                    {
+                        ApplicationTypeName = "MyApp",
+                        CertThumbprint = "MyCert",
+                        ServiceManifestName = "MyService",
+                        EndpointName = "MyEndpoint"
+                    },
+                    new HttpsConfig
+                    {
+                        ApplicationTypeName = "MyApp",
+                        CertThumbprint = "MyCert",
+                        ServiceManifestName = "MyService",
+                        EndpointName = "MyOtherEndpoint"
+                    }
+                }
+            };
+
+            var appManifest = new ApplicationManifest
+            {
+                ServiceManifestImports = new List<ServiceManifestImport>
+                {
+                    new ServiceManifestImport
+                    {
+                        ServiceManifestRef = new ServiceManifestRef
+                        {
+                            ServiceManifestName = "MyService"
+                        }
+                    }
+                }
+            };
+
+            var endpointHandler = new HandleEndpointCert();
+
+            // w
+            endpointHandler.SetEndpointCerts(packageConfig, appManifest, "MyApp");
+
+            // t
+            var endpointBindingPolicy = appManifest
+                .ServiceManifestImports.First()
+                .Policies
+                .EndpointBindingPolicy.First();
+
+            endpointBindingPolicy.EndpointRef.Should().Be("MyEndpoint");
+            endpointBindingPolicy.CertificateRef.Should().Be("Certificate0");
+
+            var otherEndpointBindingPolicy = appManifest
+                .ServiceManifestImports.First()
+                .Policies
+                .EndpointBindingPolicy.Last();
+
+            otherEndpointBindingPolicy.EndpointRef.Should().Be("MyOtherEndpoint");
+            otherEndpointBindingPolicy.CertificateRef.Should().Be("Certificate0");
+
+            var endpointCertificate = appManifest.Certificates.EndpointCertificates.First();
             endpointCertificate.Name.Should().Be("Certificate0");
             endpointCertificate.X509FindValue.Should().Be("MyCert");
         }


### PR DESCRIPTION
Output manifest wasn't truncated before writing.
Hashing didn't load the Application Manifest properly when hashing.